### PR TITLE
Add PDF manual viewer

### DIFF
--- a/kriolos-opos-app/pom.xml
+++ b/kriolos-opos-app/pom.xml
@@ -234,6 +234,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
             <artifactId>jaxb-impl</artifactId>
             <scope>runtime</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.30</version>
+        </dependency>
 
         <dependency> 
             <groupId>org.netbeans.external</groupId>  

--- a/kriolos-opos-app/src/main/java/com/openbravo/pos/manuals/JPanelManualViewer.java
+++ b/kriolos-opos-app/src/main/java/com/openbravo/pos/manuals/JPanelManualViewer.java
@@ -1,0 +1,125 @@
+package com.openbravo.pos.manuals;
+
+import com.openbravo.basic.BasicException;
+import com.openbravo.pos.forms.AppLocal;
+import com.openbravo.pos.forms.JPanelView;
+
+import javax.swing.*;
+import javax.swing.event.ListSelectionEvent;
+import javax.swing.event.ListSelectionListener;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.rendering.PDFRenderer;
+
+/**
+ * Panel that lists bundled PDF manuals and renders them for viewing.
+ */
+public class JPanelManualViewer extends JPanel implements JPanelView {
+
+    private static final Logger LOGGER = Logger.getLogger(JPanelManualViewer.class.getName());
+    private final JList<String> fileList = new JList<>();
+    private final JPanel pagePanel = new JPanel();
+    private final Map<String, String> fileMap = new LinkedHashMap<>();
+
+    public JPanelManualViewer() {
+        setLayout(new BorderLayout());
+        pagePanel.setLayout(new BoxLayout(pagePanel, BoxLayout.Y_AXIS));
+        JScrollPane listScroll = new JScrollPane(fileList);
+        JScrollPane pageScroll = new JScrollPane(pagePanel);
+        JSplitPane split = new JSplitPane(JSplitPane.HORIZONTAL_SPLIT, listScroll, pageScroll);
+        split.setDividerLocation(200);
+        add(split, BorderLayout.CENTER);
+        loadManualList();
+        fileList.addListSelectionListener(new ListSelectionListener() {
+            @Override
+            public void valueChanged(ListSelectionEvent e) {
+                if (!e.getValueIsAdjusting()) {
+                    String key = fileList.getSelectedValue();
+                    if (key != null) {
+                        showManual(fileMap.get(key));
+                    }
+                }
+            }
+        });
+    }
+
+    private void loadManualList() {
+        try (InputStream in = getClass().getResourceAsStream("/com/openbravo/manuals/index.txt")) {
+            if (in == null) {
+                return;
+            }
+            BufferedReader reader = new BufferedReader(new InputStreamReader(in, "UTF-8"));
+            String line;
+            DefaultListModel<String> model = new DefaultListModel<>();
+            while ((line = reader.readLine()) != null) {
+                if (line.trim().isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                int idx = line.indexOf('=');
+                if (idx > 0) {
+                    String file = line.substring(0, idx).trim();
+                    String name = line.substring(idx + 1).trim();
+                    fileMap.put(name, file);
+                    model.addElement(name);
+                }
+            }
+            fileList.setModel(model);
+        } catch (IOException ex) {
+            LOGGER.log(Level.WARNING, null, ex);
+        }
+    }
+
+    private void showManual(String file) {
+        pagePanel.removeAll();
+        if (file == null) {
+            return;
+        }
+        try (InputStream in = getClass().getResourceAsStream("/com/openbravo/manuals/" + file)) {
+            if (in == null) {
+                return;
+            }
+            PDDocument doc = PDDocument.load(in);
+            PDFRenderer renderer = new PDFRenderer(doc);
+            for (int i = 0; i < doc.getNumberOfPages(); i++) {
+                BufferedImage img = renderer.renderImageWithDPI(i, 150);
+                JLabel lbl = new JLabel(new ImageIcon(img));
+                lbl.setAlignmentX(Component.LEFT_ALIGNMENT);
+                pagePanel.add(lbl);
+            }
+            doc.close();
+            pagePanel.revalidate();
+            pagePanel.repaint();
+        } catch (IOException ex) {
+            LOGGER.log(Level.WARNING, null, ex);
+        }
+    }
+
+    @Override
+    public String getTitle() {
+        return AppLocal.getIntString("Menu.UserManuals");
+    }
+
+    @Override
+    public void activate() throws BasicException {
+    }
+
+    @Override
+    public boolean deactivate() {
+        return true;
+    }
+
+    @Override
+    public JComponent getComponent() {
+        return this;
+    }
+}

--- a/kriolos-opos-app/src/main/resources/com/openbravo/manuals/index.txt
+++ b/kriolos-opos-app/src/main/resources/com/openbravo/manuals/index.txt
@@ -1,0 +1,2 @@
+manual-en.pdf=Sample Manual (EN)
+manual-pt.pdf=Manual de Exemplo (PT)

--- a/kriolos-opos-app/src/main/resources/com/openbravo/manuals/manual-en.pdf
+++ b/kriolos-opos-app/src/main/resources/com/openbravo/manuals/manual-en.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 45 >>
+stream
+BT /F1 24 Tf 100 700 Td(Hello, Manual!) Tj ET
+endstream
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000357 00000 n 
+0000000300 00000 n 
+0000000174 00000 n 
+0000000079 00000 n 
+0000000009 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+406
+%%EOF

--- a/kriolos-opos-app/src/main/resources/com/openbravo/manuals/manual-pt.pdf
+++ b/kriolos-opos-app/src/main/resources/com/openbravo/manuals/manual-pt.pdf
@@ -1,0 +1,32 @@
+%PDF-1.4
+5 0 obj
+<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>
+endobj
+4 0 obj
+<< /Length 42 >>
+stream
+BT /F1 24 Tf 100 700 Td(Ol Manual!) Tj ET
+endstream
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] /Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+xref
+0 6
+0000000000 65535 f 
+0000000354 00000 n 
+0000000297 00000 n 
+0000000171 00000 n 
+0000000079 00000 n 
+0000000009 00000 n 
+trailer
+<< /Size 6 /Root 1 0 R >>
+startxref
+403
+%%EOF

--- a/kriolos-opos-app/src/main/resources/com/openbravo/pos/templates/Menu.Root.bs
+++ b/kriolos-opos-app/src/main/resources/com/openbravo/pos/templates/Menu.Root.bs
@@ -153,6 +153,10 @@ group = menu.addGroup("Menu.Backoffice");
         submenu.addPanel("/com/openbravo/images/reports.png", "Menu.Tools.MissingData", "/com/openbravo/reports/tools_missingdata.bs");
         submenu.addPanel("/com/openbravo/images/reports.png", "Menu.Tools.InvalidData", "/com/openbravo/reports/tools_invaliddata.bs");
 
+
+    group = menu.addGroup("Menu.UserManuals");
+        group.addPanel("/com/openbravo/images/reports.png", "Menu.UserManuals", "com.openbravo.pos.manuals.JPanelManualViewer");
+
     group = menu.addGroup("Menu.System");
     group.addChangePasswordAction();
     group.addPanel("/com/openbravo/images/configuration.png", "Menu.Configuration", "com.openbravo.pos.config.JPanelConfiguration");

--- a/kriolos-opos-app/src/main/resources/pos_messages.properties
+++ b/kriolos-opos-app/src/main/resources/pos_messages.properties
@@ -737,6 +737,7 @@ Menu.UserVoids=Voids by User
 Menu.Utilities=Utilities
 Menu.UtilityOptions=Utilities Options
 Menu.Vouchers=Vouchers
+Menu.UserManuals=User Manuals
 message.at=at
 message.BadPassword=Invalid Password. Please Retry
 message.breakoverandcheckedin='s Break is over and Checked In at

--- a/kriolos-opos-i18n/src/main/resources/pos_messages_pt.properties
+++ b/kriolos-opos-i18n/src/main/resources/pos_messages_pt.properties
@@ -732,6 +732,7 @@ Menu.UserVoids=Vazios por usuário
 Menu.Utilities=Utilitarios
 Menu.UtilityOptions=Opções de utilitários
 Menu.Vouchers=Vales de desconto
+Menu.UserManuals=Manuais
 message.at=em
 message.BadPassword=Palavra-passe inválida. Tente de novo
 message.breakoverandcheckedin=, a pausa foi terminada e entrou em

--- a/kriolos-opos-i18n_pt/src/main/resources/pos_messages_pt.properties
+++ b/kriolos-opos-i18n_pt/src/main/resources/pos_messages_pt.properties
@@ -731,6 +731,7 @@ Menu.UserVoids=Vazios por usuário
 Menu.Utilities=Utilitarios
 Menu.UtilityOptions=Opções de utilitários
 Menu.Vouchers=Vales de desconto
+Menu.UserManuals=Manuais
 message.at=em
 message.BadPassword=Palavra-passe inválida. Tente de novo
 message.breakoverandcheckedin=, a pausa foi terminada e entrou em


### PR DESCRIPTION
## Summary
- add pdfbox dependency for rendering PDFs
- provide minimal manual PDFs and index
- implement `JPanelManualViewer` for listing and viewing manuals
- update menu to open Manual Viewer
- translate new menu label in English and Portuguese

## Testing
- `mvn -q -pl kriolos-opos-app -am -DskipTests package` *(fails: `mvn: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68575c294df0832a82f1a96620523dce